### PR TITLE
Add cargo and alacritty install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # useful_scripts
+
+A collection of scripts, dotfiles, and playbooks I use to bootstrap development environments across Linux, macOS, and Windows.
+
+## Repo structure
+- `ansible_playbooks/` – playbooks for setting up shells, vim/nvim, tmux, node, and copying scripts.
+- `create_hotspot_on_linux/` – configuration and notes for running a Linux Wi‑Fi hotspot.
+- `linux-setup/` – personal setup notes for Linux desktops.
+- `mac_setup/` – macOS-specific tweaks and utility scripts.
+- `random_scripts/` – assorted helper scripts (video conversion, display tweaks, etc.).
+- `shell_setup/` – shell configuration files (bash/zsh aliases, profiles).
+- `tmux/` – tmux configuration and helper scripts for session/project selection.
+- `vim/` – vim/neovim configuration files and installation helpers.
+- `windows/` – PowerShell one-liners and notes.
+- `zen-setup/` – configuration exports and notes for the Zen browser.
+
+## Quick start
+### Configure a dev machine with Ansible
+1. Install Ansible on your target machine.
+2. Clone this repository to the machine.
+3. Run the top-level playbook to install shell tooling, editors, tmux, and node:
+   ```bash
+   ansible-playbook setup_dev_machine.yml
+   ```
+4. Adjust individual playbooks in `ansible_playbooks/` if you want to run only part of the setup.
+
+### Using individual scripts
+- Scripts in `random_scripts/` are standalone helpers. Inspect each script to confirm dependencies (e.g., `ffmpeg` for video tools) before running.
+- Copy or symlink configuration files (e.g., `tmux/tmux.conf`, `vim/vimrc`) into your home directory to apply them.
+- tmux helper scripts such as `tmux/select-project` expect `fzf` and default project directories; tweak the paths to match your environment.
+
+## Contributing
+Issues and pull requests are welcome. Feel free to file an issue if something is unclear or a script could be improved.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # useful_scripts
 
-A collection of scripts, dotfiles, and playbooks I use to bootstrap development environments across Linux, macOS, and Windows.
+A collection of scripts, dotfiles, and playbooks I use to bootstrap development environments across Linux, macOS, and Windows (well, Windows not really, only if I'm forced to)
 
 ## Repo structure
-- `ansible_playbooks/` – playbooks for setting up shells, vim/nvim, tmux, node, and copying scripts.
+- `ansible_playbooks/` – playbooks for setting up shells, vim/nvim, tmux, node, and copying scripts from other folders in this repo
 - `create_hotspot_on_linux/` – configuration and notes for running a Linux Wi‑Fi hotspot.
 - `linux-setup/` – personal setup notes for Linux desktops.
 - `mac_setup/` – macOS-specific tweaks and utility scripts.
@@ -17,12 +17,15 @@ A collection of scripts, dotfiles, and playbooks I use to bootstrap development 
 ## Quick start
 ### Configure a dev machine with Ansible
 1. Install Ansible on your target machine.
-2. Clone this repository to the machine.
-3. Run the top-level playbook to install shell tooling, editors, tmux, and node:
+   - Linux: `sudo apt install ansible`
+   - Mac: `brew install ansible`
+   - Windows: Please don't, thx
+2. Clone this repository to the machine
+   - `git clone https://github.com/LasseWolter/useful_scripts.git`
+3. Run the top-level playbook to install shell tooling, editors, tmux, node, etc:
    ```bash
    ansible-playbook setup_dev_machine.yml
    ```
-4. Adjust individual playbooks in `ansible_playbooks/` if you want to run only part of the setup.
 
 ### Using individual scripts
 - Scripts in `random_scripts/` are standalone helpers. Inspect each script to confirm dependencies (e.g., `ffmpeg` for video tools) before running.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ A collection of scripts, dotfiles, and playbooks I use to bootstrap development 
    - Windows: Please don't, thx
 2. Clone this repository to the machine
    - `git clone https://github.com/LasseWolter/useful_scripts.git`
-3. Run the top-level playbook to install shell tooling, editors, tmux, node, etc:
+3. Run any command with sudo (e.g. `sudo ls`) so the terminal session can run `sudo` commands because some of the commands in the ansible scripts require elevated priveleges
+   - do NOT run the whole ansible command below as `sudo`
+4. Run the top-level playbook to install shell tooling, editors, tmux, node, etc:
    ```bash
    ansible-playbook setup_dev_machine.yml
    ```

--- a/ansible_playbooks/install_alacritty.yml
+++ b/ansible_playbooks/install_alacritty.yml
@@ -1,0 +1,54 @@
+---
+- name: Install Alacritty terminal emulator https://alacritty.org/
+  hosts: localhost
+  tasks:
+    - name: Install Rust toolchain (cargo)
+      shell: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      args:
+        creates: ~/.cargo/bin/cargo
+
+    - name: Install Alacritty deps (Debian)
+      become: yes
+      apt:
+        name:
+          - cmake
+          - g++
+          - pkg-config
+          - libfontconfig1-dev
+          - libxcb-xfixes0-dev
+          - libxkbcommon-dev
+          - python3
+        state: present
+      when: ansible_os_family == 'Debian'
+
+    - name: Install Alacritty via cargo
+      shell: |
+        ~/.cargo/bin/cargo install alacritty --locked
+      args:
+        creates: ~/.cargo/bin/alacritty
+      environment:
+        PATH: "{{ ansible_env.HOME }}/.cargo/bin:{{ ansible_env.PATH }}"
+
+    - name: Get alacritty icon for desktop entry (Debian)
+      shell: |
+        mkdir -p ~/.local/share/alacritty
+        wget https://github.com/dfl0/mac-icons/raw/main/alacritty/icons/smooth/alacritty_smooth_full.png -O ~/.local/share/alacritty/icon.png
+      args:
+        creates: ~/.local/share/alacritty/logo.pnhg
+      when: ansible_os_family == 'Debian'
+
+    - name: Create Alacritty desktop file (Debian)
+      copy:
+        dest: "{{ ansible_env.HOME }}/.local/share/applications/alacritty.desktop"
+        mode: '0644'
+        content: |
+          [Desktop Entry]
+          Name=Alacritty
+          Comment=Alacritty Terminal Emulator
+          Exec={{ ansible_env.HOME }}/.cargo/bin/alacritty
+          Icon={{ ansible_env.HOME }}/.local/share/alacritty/icon.png
+          Terminal=false
+          Type=Application
+          Categories=System;TerminalEmulator;
+      when: ansible_os_family == 'Debian'

--- a/ansible_playbooks/setup_shell.yml
+++ b/ansible_playbooks/setup_shell.yml
@@ -127,17 +127,3 @@
         brew install --cask font-jetbrains-mono-nerd-font
       when: ansible_os_family == 'Darwin'
 
-    - name: Install Rust toolchain (cargo)
-      shell: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      args:
-        creates: ~/.cargo/bin/cargo
-
-    - name: Install Alacritty via cargo
-      shell: |
-        ~/.cargo/bin/cargo install alacritty --locked
-      args:
-        creates: ~/.cargo/bin/alacritty
-      environment:
-        PATH: "{{ ansible_env.HOME }}/.cargo/bin:{{ ansible_env.PATH }}"
-

--- a/ansible_playbooks/setup_shell.yml
+++ b/ansible_playbooks/setup_shell.yml
@@ -127,3 +127,17 @@
         brew install --cask font-jetbrains-mono-nerd-font
       when: ansible_os_family == 'Darwin'
 
+    - name: Install Rust toolchain (cargo)
+      shell: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      args:
+        creates: ~/.cargo/bin/cargo
+
+    - name: Install Alacritty via cargo
+      shell: |
+        ~/.cargo/bin/cargo install alacritty --locked
+      args:
+        creates: ~/.cargo/bin/alacritty
+      environment:
+        PATH: "{{ ansible_env.HOME }}/.cargo/bin:{{ ansible_env.PATH }}"
+

--- a/setup_dev_machine.yml
+++ b/setup_dev_machine.yml
@@ -1,4 +1,5 @@
 ---
+- import_playbook: ansible_playbooks/install_alacritty.yml
 - import_playbook: ansible_playbooks/setup_shell.yml
 - import_playbook: ansible_playbooks/setup_vim_configs.yml
 - import_playbook: ansible_playbooks/setup_tmux.yml

--- a/shell_setup/omzsh/zshrc
+++ b/shell_setup/omzsh/zshrc
@@ -8,6 +8,7 @@ fi
 # Update PATH variable
 export PATH="$PATH:$HOME/bin"
 export PATH="$PATH:$HOME/.local/bin"
+export PATH="$PATH:$HOME/.cargo/bin"
 export PATH="$PATH:/opt/mssql-tools18/bin"
 export PATH="$PATH:$HOME/.scripts"
 export PATH="$PATH:$HOME/.local/bin/pact/bin"


### PR DESCRIPTION
## Summary
- install Rust tooling via rustup to provide cargo during shell setup
- install Alacritty using cargo with PATH configured for the playbook run

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692895632bbc832babdd51d7f407f286)